### PR TITLE
specify commit of waf key

### DIFF
--- a/scripts/get_waf.sh
+++ b/scripts/get_waf.sh
@@ -6,7 +6,8 @@ set -e
 WAFVERSION=2.0.21
 WAFTARBALL=waf-$WAFVERSION.tar.bz2
 WAFURL=https://waf.io/$WAFTARBALL
-WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/raw/master/utils/pubkey.asc
+WAFUPSREAMKEYCOMMIT=edde20a6425a5c3eb6b47d5f3f5c4fbc93fed5f4
+WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/raw/$WAFUPSREAMKEYCOMMIT/utils/pubkey.asc
 
 WAFBUILDDIR=`mktemp -d`
 


### PR DESCRIPTION
waf will have to update their public keys as they expire, so the key downloaded should correspond to the key waf were using when they encrypted the version of waf specified by WAFVERSION. This will allow old versions of aubio to continue to work when waf update their key.